### PR TITLE
Add LED blink and debug UART

### DIFF
--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -21,6 +21,7 @@
 
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */
+#include <string.h>
 
 /* USER CODE END Includes */
 
@@ -63,11 +64,17 @@ static void MX_TIM3_Init(void);
 /* USER CODE BEGIN PFP */
 
 void UpdatePWM(void);
+void Debug_Send(const char *msg);
 
 /* USER CODE END PFP */
 
 /* Private user code ---------------------------------------------------------*/
 /* USER CODE BEGIN 0 */
+void Debug_Send(const char *msg)
+{
+  HAL_UART_Transmit(&huart2, (uint8_t *)msg, strlen(msg), HAL_MAX_DELAY);
+}
+
 
 /* USER CODE END 0 */
 
@@ -109,6 +116,7 @@ int main(void)
   HAL_TIM_PWM_Start(&htim2, TIM_CHANNEL_3);
   HAL_TIM_PWM_Start(&htim3, TIM_CHANNEL_1);
   HAL_TIM_PWM_Start(&htim3, TIM_CHANNEL_2);
+  Debug_Send("System Init Complete\r\n");
 
   /* USER CODE END 2 */
 
@@ -119,6 +127,8 @@ int main(void)
     /* USER CODE END WHILE */
 
     /* USER CODE BEGIN 3 */
+    HAL_GPIO_TogglePin(LD2_GPIO_Port, LD2_Pin);
+    HAL_Delay(500);
     UpdatePWM();
   }
   /* USER CODE END 3 */
@@ -369,6 +379,7 @@ void Error_Handler(void)
 {
   /* USER CODE BEGIN Error_Handler_Debug */
   /* User can add his own implementation to report the HAL error return state */
+  Debug_Send("Error_Handler\r\n");
   __disable_irq();
   while (1)
   {


### PR DESCRIPTION
## Summary
- add Debug_Send helper for UART debug messages
- report errors via UART and print init message
- toggle LD2 in main loop to blink the LED

## Testing
- `make -C Release all` *(fails: multiple target patterns)*

------
https://chatgpt.com/codex/tasks/task_e_68546310cb30832b882ddfcc0839b622