### PR TITLE
Improve I2C recovery logic

### DIFF
--- a/Core/Src/drone_control.c
+++ b/Core/Src/drone_control.c
@@ -27,6 +27,15 @@ extern volatile uint8_t control_enabled;
 
 static uint32_t last_button_time = 0;
 
+/* Simple cycle-based delay used during I2C bus recovery */
+static void ShortDelay(void)
+{
+    for (volatile uint32_t i = 0; i < 1000; ++i)
+    {
+        __NOP();
+    }
+}
+
 /* Filter state for accelerometer low-pass and gyroscope high-pass */
 static MPU6050_Physical_t accel_lp = {0};
 static MPU6050_Physical_t gyro_hp = {0};
@@ -180,13 +189,13 @@ void I2C_ResetBus(void)
     for (int i = 0; i < 9; i++)
     {
         HAL_GPIO_WritePin(GPIOB, GPIO_PIN_8, GPIO_PIN_SET);
-        HAL_Delay(1);
+        ShortDelay();
         HAL_GPIO_WritePin(GPIOB, GPIO_PIN_8, GPIO_PIN_RESET);
-        HAL_Delay(1);
+        ShortDelay();
     }
 
     HAL_GPIO_WritePin(GPIOB, GPIO_PIN_8|GPIO_PIN_9, GPIO_PIN_SET);
-    HAL_Delay(1);
+    ShortDelay();
 
     hi2c1.Instance = I2C1;
     hi2c1.Init.ClockSpeed = 100000;

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -51,6 +51,7 @@
 #define PID_KD_YAW     0.01f
 
 #define BASE_THROTTLE  1200.0f
+#define MAX_I2C_RETRIES 3
 /* USER CODE END PD */
 
 /* Private macro -------------------------------------------------------------*/
@@ -100,6 +101,7 @@ float integral_roll    = 0.0f;
 float last_error_yaw   = 0.0f;
 float integral_yaw     = 0.0f;
 uint32_t last_pid_time = 0;
+uint8_t i2c_retry_count = 0;
 
 /* USER CODE END PV */
 
@@ -198,7 +200,15 @@ int main(void)
                         PWM_D3_Target = 0;
                         UpdatePWM();
                         I2C_ResetBus();
+                        if (++i2c_retry_count > MAX_I2C_RETRIES)
+                        {
+                                Error_Handler();
+                        }
                         continue;
+                }
+                else
+                {
+                        i2c_retry_count = 0;
                 }
                 MPU6050_ConvertToPhysical(&imu_data, &imu_phys);
                 IMU_Filter(&imu_phys, &imu_filt);


### PR DESCRIPTION
## Summary
- implement ShortDelay and use it for I2C bus recovery
- limit I2C retries in main loop to prevent infinite reset loops

## Testing
- `make -C Release all` *(fails: multiple target patterns)*

------
https://chatgpt.com/codex/tasks/task_e_6856c89254b4832b83cb13657567ce37