### PR TITLE
Implement new IMU filtering and PID helpers

### DIFF
--- a/Core/Inc/drone_control.h
+++ b/Core/Inc/drone_control.h
@@ -5,6 +5,16 @@
 
 #define IMU_WINDOW_SIZE 10
 
+typedef struct {
+    float kp;
+    float ki;
+    float kd;
+    float last_err;
+    float integral;
+} PID_t;
+
+float PID_Update(PID_t *pid, float error, float dt);
+
 
 void Debug_Send(const char *msg);
 void SoftStartPWM(uint32_t *current, const uint32_t target);

--- a/Core/Src/drone_control.c
+++ b/Core/Src/drone_control.c
@@ -2,6 +2,14 @@
 #include <string.h>
 #include <stdio.h>
 
+/* USER CODE BEGIN 0 */
+#define ACCEL_LP_ALPHA   0.2f
+#define GYRO_HP_ALPHA    0.8f
+#define PWM_RAMP_KP      0.2f
+#define PWM_MAX_STEP     1
+#define SHORT_DELAY_CYCLES 1000
+/* USER CODE END 0 */
+
 extern I2C_HandleTypeDef hi2c1;
 extern TIM_HandleTypeDef htim2;
 extern TIM_HandleTypeDef htim3;
@@ -20,6 +28,7 @@ extern volatile uint32_t PWM_D3_Target;
 extern MPU6050_Physical_t imu_avg;
 extern MPU6050_Physical_t imu_window[];
 extern MPU6050_Physical_t imu_sum;
+extern MPU6050_Physical_t imu_bias;
 extern uint8_t imu_index;
 extern uint8_t imu_count;
 
@@ -32,10 +41,10 @@ static uint32_t last_button_time = 0;
 /* Simple cycle-based delay used during I2C bus recovery */
 static void ShortDelay(void)
 {
-	for (volatile uint32_t i = 0; i < 1000; ++i)
-	{
-		__NOP();
-	}
+        for (volatile uint32_t i = 0; i < SHORT_DELAY_CYCLES; ++i)
+        {
+                __NOP();
+        }
 }
 
 /* Filter state for accelerometer low-pass and gyroscope high-pass */
@@ -45,26 +54,22 @@ static MPU6050_Physical_t gyro_prev_in = {0};
 
 void IMU_Filter(const MPU6050_Physical_t *in, MPU6050_Physical_t *out)
 {
-	const float alpha_acc = 0.2f;  /* low-pass smoothing factor */
-	const float alpha_gyro = 0.8f; /* high-pass coefficient */
+        /* low-pass / high-pass smoothing using macros */
+        out->accel_x = ACCEL_LP_ALPHA * (in->accel_x - imu_bias.accel_x) +
+                       (1.0f - ACCEL_LP_ALPHA) * accel_lp.accel_x;
+        out->accel_y = ACCEL_LP_ALPHA * (in->accel_y - imu_bias.accel_y) +
+                       (1.0f - ACCEL_LP_ALPHA) * accel_lp.accel_y;
+        out->accel_z = ACCEL_LP_ALPHA * (in->accel_z - imu_bias.accel_z) +
+                       (1.0f - ACCEL_LP_ALPHA) * accel_lp.accel_z;
+        accel_lp = *out;
 
-	out->accel_x = alpha_acc * in->accel_x + (1.0f - alpha_acc) * accel_lp.accel_x;
-	out->accel_y = alpha_acc * in->accel_y + (1.0f - alpha_acc) * accel_lp.accel_y;
-	out->accel_z = alpha_acc * in->accel_z + (1.0f - alpha_acc) * accel_lp.accel_z;
-	accel_lp = *out;
+        out->gyro_x = GYRO_HP_ALPHA * (gyro_hp.gyro_x + in->gyro_x - gyro_prev_in.gyro_x);
+        out->gyro_y = GYRO_HP_ALPHA * (gyro_hp.gyro_y + in->gyro_y - gyro_prev_in.gyro_y);
+        out->gyro_z = GYRO_HP_ALPHA * (gyro_hp.gyro_z + in->gyro_z - gyro_prev_in.gyro_z);
 
-	out->gyro_x = alpha_gyro * (gyro_hp.gyro_x + in->gyro_x - gyro_prev_in.gyro_x);
-	out->gyro_y = alpha_gyro * (gyro_hp.gyro_y + in->gyro_y - gyro_prev_in.gyro_y);
-	out->gyro_z = alpha_gyro * (gyro_hp.gyro_z + in->gyro_z - gyro_prev_in.gyro_z);
-
-	gyro_prev_in.gyro_x = in->gyro_x;
-	gyro_prev_in.gyro_y = in->gyro_y;
-	gyro_prev_in.gyro_z = in->gyro_z;
-	gyro_hp.gyro_x = out->gyro_x;
-	gyro_hp.gyro_y = out->gyro_y;
-	gyro_hp.gyro_z = out->gyro_z;
-
-	out->temp = in->temp;
+        gyro_prev_in = *in;
+        gyro_hp     = *out;
+        out->temp   = in->temp;
 }
 
 void Debug_Send(const char *msg)
@@ -116,24 +121,32 @@ void IMU_UpdateAverage(const MPU6050_Physical_t *sample)
 	imu_avg.gyro_x  = imu_sum.gyro_x  / div;
 	imu_avg.gyro_y  = imu_sum.gyro_y  / div;
 	imu_avg.gyro_z  = imu_sum.gyro_z  / div;
-	imu_avg.temp    = imu_sum.temp    / div;
+        imu_avg.temp    = imu_sum.temp    / div;
 }
 
-#define PWM_MAX_STEP 1
-#define Kp 0.2f
+float PID_Update(PID_t *pid, float error, float dt)
+{
+        pid->integral += error * dt;
+        float derivative = (error - pid->last_err) / dt;
+        pid->last_err = error;
+        return pid->kp * error + pid->ki * pid->integral + pid->kd * derivative;
+}
+
 
 void SoftStartPWM(uint32_t *current, const uint32_t target)
 {
-	uint32_t desired = target;
+        uint32_t desired = target;
 
-	/* Optional branch to ramp down smoothly when control is disabled */
-	if (!control_enabled)
-	{
-		desired = 0;
-	}
+        /* Optional branch to ramp down smoothly when control is disabled */
+        if (!control_enabled)
+        {
+                memset(&accel_lp, 0, sizeof(accel_lp));
+                memset(&gyro_hp,  0, sizeof(gyro_hp));
+                desired = 0;
+        }
 
 	int32_t error = (int32_t)desired - (int32_t)(*current);
-	int32_t step = (int32_t)(Kp * error);
+        int32_t step = (int32_t)(PWM_RAMP_KP * error);
 
 	if (step > PWM_MAX_STEP) step = PWM_MAX_STEP;
 	else if (step < -PWM_MAX_STEP) step = -PWM_MAX_STEP;

--- a/Core/Src/mpu6050.c
+++ b/Core/Src/mpu6050.c
@@ -2,6 +2,7 @@
 
 /* USER CODE BEGIN 0 */
 #include <stdlib.h>
+#include <stdbool.h>
 #define MPU6050_ADDR            (0x68 << 1)
 #define MPU6050_REG_PWR_MGMT_1  0x6B
 #define MPU6050_REG_SMPLRT_DIV  0x19
@@ -14,14 +15,21 @@
 /* USER CODE END 0 */
 
 /* USER CODE BEGIN 1 */
+#define WHO_AM_I_REG  0x75
+#define WHO_AM_I_VAL  0x68
 HAL_StatusTypeDef MPU6050_Init(I2C_HandleTypeDef *hi2c)
 {
 	uint8_t data;
 
-	/* Wake up the sensor */
-	data = 0;
-	if (HAL_I2C_Mem_Write(hi2c, MPU6050_ADDR, MPU6050_REG_PWR_MGMT_1, 1, &data, 1, HAL_MAX_DELAY) != HAL_OK)
-		return HAL_ERROR;
+        /* Wake up the sensor */
+        data = 0;
+        if (HAL_I2C_Mem_Write(hi2c, MPU6050_ADDR, MPU6050_REG_PWR_MGMT_1, 1, &data, 1, HAL_MAX_DELAY) != HAL_OK)
+                return HAL_ERROR;
+
+        /* confirm MPU6050 identity */
+        uint8_t who = 0;
+        if (HAL_I2C_Mem_Read(hi2c, MPU6050_ADDR, WHO_AM_I_REG, 1, &who, 1, HAL_MAX_DELAY) != HAL_OK || who != WHO_AM_I_VAL)
+                return HAL_ERROR;
 
 	/* Set sample rate to 1kHz/(1+0) = 1kHz */
 	data = 0;
@@ -69,8 +77,13 @@ void MPU6050_ConvertToPhysical(const MPU6050_Data_t *raw, MPU6050_Physical_t *ou
 	const float gyro_lsb  = 65.5f;     /* LSB/(deg/s) for +-500dps */
 	const float g = 9.80665f;          /* m/s^2 per g */
 
-	static MPU6050_Data_t prev = {0};
-	MPU6050_Data_t clean = *raw;
+        static MPU6050_Data_t prev = {0};
+        static bool first_call = true;
+        if (first_call) {
+                prev = *raw;
+                first_call = false;
+        }
+        MPU6050_Data_t clean = *raw;
 
 	if (abs((int32_t)raw->accel_x - prev.accel_x) > ACCEL_SPIKE_THRESH) clean.accel_x = prev.accel_x; else prev.accel_x = raw->accel_x;
 	if (abs((int32_t)raw->accel_y - prev.accel_y) > ACCEL_SPIKE_THRESH) clean.accel_y = prev.accel_y; else prev.accel_y = raw->accel_y;


### PR DESCRIPTION
## Summary
- add PID helpers and macros for filtering and PWM ramping
- verify MPU6050 identity and handle first-call spike filtering
- implement IMU bias calibration and yaw PID control
- reset filter state when disarmed and rename throttle override variable

## Testing
- `make all` *(fails: multiple target patterns)*

------
https://chatgpt.com/codex/tasks/task_e_6856cd19b918832bb9f2ecb07ccfa2cf