### PR TITLE
Fix PID reset and linker path

### DIFF
--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -208,12 +208,12 @@ int main(void)
 			if (duration >= BUTTON_LONG_PRESS_MS)
 			{
 				Debug_Send("Calibration\r\n");
-				integral_pitch = 0.0f;
-				integral_roll = 0.0f;
-				integral_yaw = 0.0f;
-				last_error_pitch = 0.0f;
-				last_error_roll = 0.0f;
-				last_error_yaw = 0.0f;
+                                pid_pitch.integral = 0.0f;
+                                pid_roll.integral  = 0.0f;
+                                pid_yaw.integral   = 0.0f;
+                                pid_pitch.last_err = 0.0f;
+                                pid_roll.last_err  = 0.0f;
+                                pid_yaw.last_err   = 0.0f;
 				control_state = CONTROL_DISARMED;
 			}
 			else if (duration >= BUTTON_DEBOUNCE_MS)

--- a/Release/makefile
+++ b/Release/makefile
@@ -60,8 +60,8 @@ all: main-build
 main-build: drone_nucleo_F446RE.elf secondary-outputs
 
 # Tool invocations
-drone_nucleo_F446RE.elf drone_nucleo_F446RE.map: $(OBJS) $(USER_OBJS) C:\Users\Aliso\Documents\GIT\drone_nucleo_F446RE\STM32F446RETX_FLASH.ld makefile objects.list $(OPTIONAL_TOOL_DEPS)
-	arm-none-eabi-gcc -o "drone_nucleo_F446RE.elf" @"objects.list" $(USER_OBJS) $(LIBS) -mcpu=cortex-m4 -T"C:\Users\Aliso\Documents\GIT\drone_nucleo_F446RE\STM32F446RETX_FLASH.ld" --specs=nosys.specs -Wl,-Map="drone_nucleo_F446RE.map" -Wl,--gc-sections -static --specs=nano.specs -mfpu=fpv4-sp-d16 -mfloat-abi=hard -mthumb -Wl,--start-group -lc -lm -Wl,--end-group
+drone_nucleo_F446RE.elf drone_nucleo_F446RE.map: $(OBJS) $(USER_OBJS) ../STM32F446RETX_FLASH.ld makefile objects.list $(OPTIONAL_TOOL_DEPS)
+	arm-none-eabi-gcc -o "drone_nucleo_F446RE.elf" @"objects.list" $(USER_OBJS) $(LIBS) -mcpu=cortex-m4 -T../STM32F446RETX_FLASH.ld --specs=nosys.specs -Wl,-Map="drone_nucleo_F446RE.map" -Wl,--gc-sections -static --specs=nano.specs -mfpu=fpv4-sp-d16 -mfloat-abi=hard -mthumb -Wl,--start-group -lc -lm -Wl,--end-group
 	@echo 'Finished building target: $@'
 	@echo ' '
 


### PR DESCRIPTION
## Summary
- reset PID structures properly during calibration
- fix linker path in Release makefile for Linux

## Testing
- `make -C Release main-build` *(fails: arm-none-eabi-gcc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856cfca6dc0832bad45db0d7764df36